### PR TITLE
refactor: settle facade return types and cross-context associations

### DIFF
--- a/.claude/agents/boundary-checker.md
+++ b/.claude/agents/boundary-checker.md
@@ -99,9 +99,15 @@ schemas, or `adapters/` modules.
      `config/config.exs`. That registry names every context's handlers by design; it is
      the wiring, not a boundary crossing. Test code invoking such a handler directly to
      exercise the wiring is integration-test infrastructure, not production reach-in.
+   - **An entity B's facade RETURNS.** `Provider.get_staff_member/2` yields
+     `{:ok, %StaffMember{}}`, so a caller must name the struct to spec it, match on it, or
+     read a field off it. The facade owns its return types, and the coupling is the shape of
+     B's public API rather than A's alias — see `.claude/rules/domain-architecture.md`
+     § Cross-Context Access. Flag the **query**, never the name (#1434).
 
    Note the asymmetry these exceptions preserve: **production** code in A must still never
-   name B's handler or entity modules. Only config wiring and test construction may.
+   name B's handler modules, nor an entity B's facade does not hand out. Only config wiring
+   and test construction may.
 
 **Example violation:**
 ```elixir
@@ -123,7 +129,12 @@ context's Ecto schemas / tables via `Repo` — even indirectly via
 is fine (schema-as-struct: the context module is the data-access API).
 
 **Exceptions:**
-- `KlassHero.Accounts.User` — commonly used for `belongs_to` associations (known exception)
+- **A struct another context's facade returned.** Naming it — alias, typespec, pattern
+  match, field read, or re-export through your own `@spec` — is not a violation; the facade
+  owns its return types. See `.claude/rules/domain-architecture.md` § Cross-Context Access
+  for the rule and its reasoning. There is no per-module list to consult: the test is
+  whether the module issues a query against the other context's tables, not whether it
+  names the struct.
 - **A raw-string table read (`from(p in "programs", ...)`) that carries an `acl_span`.**
   ADR 0015 lists cycle-breaking direct table access as legitimate — ProgramCatalog
   depends on Enrollment, so Enrollment cannot call its facade — and requires only that
@@ -243,11 +254,13 @@ are deliberate instances of it.
 - Both the flattened and old-DDD-derived shapes are legal simultaneously during the
   migration (see the note above `## Scope`) — a context using the old tree is not itself
   a finding, and neither is a context missing `adapters/`/`domain/` because it's flat
-- The `Accounts.User` reference is a KNOWN exception — do not flag it
+- Naming a struct another context's facade RETURNS is not a violation — do not flag it.
+  See `.claude/rules/domain-architecture.md` § Cross-Context Access; the test is whether a
+  query is issued against the other context's tables, not whether the struct is named
 - Shared (`KlassHero.Shared.*`) is universal infrastructure — accessible to all
 - A context using `Repo` on its OWN schemas is correct (schema-as-struct) — never flag it
 - A direct facade call is the DEFAULT for a cross-context read (ADR 0015) — never flag one
   for lacking an ACL. Reserve a projection for a genuinely hot read path
 - Critical severity: cross-context Repo/schema access, reaching into another context's internals
-- Warning severity: cross-context `belongs_to` beyond the User exception, an unnecessary ACL
+- Warning severity: any cross-context `belongs_to`/`has_one` (no exceptions — #1434), an unnecessary ACL
   (pure delegation — no error remapping, no business-rule masking, no cycle to break)

--- a/.claude/rules/domain-architecture.md
+++ b/.claude/rules/domain-architecture.md
@@ -121,6 +121,17 @@ not copy this into one.
   `field :x_id, :binary_id`, not deleted — deleting it silently drops a column the changeset
   still casts; and `foreign_key_constraint/2` and `unique_constraint/2` keep working either
   way, since both key off the field name rather than the association.
+  **One survives, on the cycle-breaking ground ADR 0015 already grants:**
+  `Enrollment.program` → `ProgramCatalog.Program`. ProgramCatalog depends on Enrollment for
+  capacity, so Enrollment cannot call its facade, and direct `programs` access is sanctioned
+  for that pair (`enrollment/…/acl/program_catalog_acl.ex`). `Admin.BookingLive` needs a real
+  association for its Backpex `Fields.BelongsTo` to search and sort by title. The test is the
+  ADR-0015 justification, not the module name — no other pair currently has one, and a new
+  association still has to earn it.
+  **A Backpex `Fields.BelongsTo` is a consumer no grep will find.** It names the association
+  declaratively — no `preload`, no `Repo.preload`, no `assoc/2` — and joins the other table to
+  search and sort. Check `lib/klass_hero_web/live/admin/` before concluding an association is
+  unused.
 - **One-shot migration backfills are exempt**, and only they. A module under
   `lib/klass_hero/release/` called from a migration's `up/0` may read another
   context's tables directly in raw SQL, with no facade and no `acl_span`. A facade

--- a/.claude/rules/domain-architecture.md
+++ b/.claude/rules/domain-architecture.md
@@ -101,6 +101,26 @@ not copy this into one.
 - For cross-context **reads**: **call the owning context's root facade directly** (ADR 0015). This is the default at every layer — a projection, event handler, worker or web helper calls the facade with no adapter in between. Reach for something heavier only when it earns its place:
   - an **ACL adapter** (`acl/`) when there is genuine translation to do — remapping the other context's errors into your vocabulary, masking fields behind a business rule, cycle-breaking direct table access, or a query no facade expresses. An ACL that only forwards a call is indirection without a payer; fold it into the caller.
   - a **projection** when a per-render facade call cannot serve the read path.
+- **A facade owns its return types, so naming what it returns is not a violation.**
+  `Provider.get_staff_member/2` yields `{:ok, %StaffMember{}}`, so any caller must name that
+  struct to spec it, match on it, or read a field off it — and may re-export it through its
+  own `@spec`. Alias, typespec, pattern match, field read and re-export are all fine. The
+  coupling is created by the shape of the facade's public API, not by the caller's alias;
+  chasing the alias without changing the return type would only replace a named struct with
+  an unnamed one, and under schema-as-struct the entity **is** the DTO, so a struct twin to
+  hide it is the wrong trade. The violation line is `Repo`/query access to the other
+  context's tables — that, not the alias, is what to look for. Reference: `accounts.ex`
+  names `Provider.StaffMember` in four `@spec`s and three pattern matches and issues no
+  query against Provider's tables (#1434).
+- **Never declare a `belongs_to`/`has_one` onto another context's schema.** Store the
+  correlation id as a plain `field` and read across via the facade. ADR 0001 already forbids
+  the SQL join; the association is the thing that makes one reachable, from any call site,
+  with a single `Repo.preload/2`. #1434 removed the ten that existed — eight had never been
+  preloaded at all. Two traps when removing one: without `define_field: false` the
+  `belongs_to` is the **sole** declaration of the id field, so it must be *replaced* with
+  `field :x_id, :binary_id`, not deleted — deleting it silently drops a column the changeset
+  still casts; and `foreign_key_constraint/2` and `unique_constraint/2` keep working either
+  way, since both key off the field name rather than the association.
 - **One-shot migration backfills are exempt**, and only they. A module under
   `lib/klass_hero/release/` called from a migration's `up/0` may read another
   context's tables directly in raw SQL, with no facade and no `acl_span`. A facade

--- a/lib/klass_hero/accounts/user.ex
+++ b/lib/klass_hero/accounts/user.ex
@@ -13,10 +13,6 @@ defmodule KlassHero.Accounts.User do
 
   alias KlassHero.Accounts.User
   alias KlassHero.Accounts.{UserRole, UserRoles}
-  # Cross-context references for admin dashboard preloading (read-only).
-  # Pragmatic DDD boundary crossing — see AccountLive moduledoc.
-  alias KlassHero.Family.ParentProfile
-  alias KlassHero.Provider.ProviderProfile
   alias KlassHero.Shared.Locales
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -35,9 +31,6 @@ defmodule KlassHero.Accounts.User do
     field :active_persona, Ecto.Enum, values: UserRole.valid_roles()
     field :is_admin, :boolean, default: false
     field :disabled_email_notifications, {:array, Ecto.Enum}, values: [:new_message_email], default: []
-
-    has_one :parent_profile, ParentProfile, foreign_key: :identity_id
-    has_one :provider_profile, ProviderProfile, foreign_key: :identity_id
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/klass_hero/enrollment/enrollment.ex
+++ b/lib/klass_hero/enrollment/enrollment.ex
@@ -18,6 +18,8 @@ defmodule KlassHero.Enrollment.Enrollment do
 
   import Ecto.Changeset
 
+  alias KlassHero.ProgramCatalog.Program
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   @timestamps_opts [type: :utc_datetime]
@@ -26,8 +28,13 @@ defmodule KlassHero.Enrollment.Enrollment do
   @valid_payment_methods ~w(card transfer)
 
   schema "enrollments" do
-    # ProgramCatalog owns the program; correlation id only, no association (#1434).
-    field :program_id, :binary_id
+    # The one cross-context association that survives #1434's clause 2, on ADR
+    # 0015's cycle-breaking ground: ProgramCatalog depends on Enrollment for
+    # capacity, so Enrollment cannot call its facade, and direct `programs`
+    # access is already sanctioned for this pair (see acl/program_catalog_acl.ex).
+    # Admin.BookingLive's Backpex BelongsTo field needs a real association to
+    # search and sort by title. Do not copy this to another context pair.
+    belongs_to :program, Program
     field :child_id, :binary_id
     field :parent_id, :binary_id
 

--- a/lib/klass_hero/enrollment/enrollment.ex
+++ b/lib/klass_hero/enrollment/enrollment.ex
@@ -18,8 +18,6 @@ defmodule KlassHero.Enrollment.Enrollment do
 
   import Ecto.Changeset
 
-  alias KlassHero.ProgramCatalog.Program
-
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   @timestamps_opts [type: :utc_datetime]
@@ -28,7 +26,8 @@ defmodule KlassHero.Enrollment.Enrollment do
   @valid_payment_methods ~w(card transfer)
 
   schema "enrollments" do
-    belongs_to :program, Program
+    # ProgramCatalog owns the program; correlation id only, no association (#1434).
+    field :program_id, :binary_id
     field :child_id, :binary_id
     field :parent_id, :binary_id
 

--- a/lib/klass_hero/enrollment/enrollment.ex
+++ b/lib/klass_hero/enrollment/enrollment.ex
@@ -31,7 +31,7 @@ defmodule KlassHero.Enrollment.Enrollment do
     # The one cross-context association that survives #1434's clause 2, on ADR
     # 0015's cycle-breaking ground: ProgramCatalog depends on Enrollment for
     # capacity, so Enrollment cannot call its facade, and direct `programs`
-    # access is already sanctioned for this pair (see acl/program_catalog_acl.ex).
+    # access is already sanctioned for this pair (Enrollment's ACL for ProgramCatalog).
     # Admin.BookingLive's Backpex BelongsTo field needs a real association to
     # search and sort by title. Do not copy this to another context pair.
     belongs_to :program, Program

--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -1417,7 +1417,7 @@ defmodule KlassHero.Messaging do
       |> MessageQueries.not_deleted()
       |> MessageQueries.order_by_newest()
       |> MessageQueries.paginate(opts)
-      |> MessageQueries.preload_assocs([:sender, :attachments])
+      |> MessageQueries.preload_assocs([:attachments])
       |> Repo.all()
 
     messages = Enum.take(results, limit)
@@ -1443,14 +1443,14 @@ defmodule KlassHero.Messaging do
     |> Kernel.||(0)
   end
 
-  # Builds a sender_id => display-name map from preloaded messages, skipping
-  # messages whose sender wasn't loaded (last-write-wins on duplicate senders).
+  # Builds a sender_id => display-name map. Ids Accounts cannot resolve are
+  # omitted rather than raising, so a dangling correlation id degrades to
+  # "Unknown" at the call site instead of failing the whole page.
   defp build_sender_names_map(messages) do
     messages
-    |> Enum.reject(fn m ->
-      match?(%Ecto.Association.NotLoaded{}, m.sender) or is_nil(m.sender)
-    end)
-    |> Map.new(fn m -> {m.sender_id, m.sender.name} end)
+    |> Enum.map(& &1.sender_id)
+    |> Enum.uniq()
+    |> Accounts.get_display_names()
   end
 
   # === Persistence — participants ===

--- a/lib/klass_hero/messaging/email_reply.ex
+++ b/lib/klass_hero/messaging/email_reply.ex
@@ -12,7 +12,6 @@ defmodule KlassHero.Messaging.EmailReply do
 
   import Ecto.Changeset
 
-  alias KlassHero.Accounts.User
   alias KlassHero.Messaging.InboundEmail
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -28,7 +27,6 @@ defmodule KlassHero.Messaging.EmailReply do
     field :sent_by_id, :binary_id
 
     belongs_to :inbound_email, InboundEmail, foreign_key: :inbound_email_id, define_field: false
-    belongs_to :sent_by, User, foreign_key: :sent_by_id, define_field: false
 
     timestamps()
   end

--- a/lib/klass_hero/messaging/inbound_email.ex
+++ b/lib/klass_hero/messaging/inbound_email.ex
@@ -16,8 +16,6 @@ defmodule KlassHero.Messaging.InboundEmail do
 
   import Ecto.Changeset
 
-  alias KlassHero.Accounts.User
-
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   @timestamps_opts [type: :utc_datetime]
@@ -38,8 +36,6 @@ defmodule KlassHero.Messaging.InboundEmail do
     field :read_by_id, :binary_id
     field :read_at, :utc_datetime_usec
     field :received_at, :utc_datetime_usec
-
-    belongs_to :read_by, User, foreign_key: :read_by_id, define_field: false
 
     timestamps()
   end

--- a/lib/klass_hero/messaging/message.ex
+++ b/lib/klass_hero/messaging/message.ex
@@ -13,7 +13,6 @@ defmodule KlassHero.Messaging.Message do
 
   import Ecto.Changeset
 
-  alias KlassHero.Accounts.User
   alias KlassHero.Messaging.Attachment
   alias KlassHero.Messaging.Conversation
 
@@ -32,7 +31,6 @@ defmodule KlassHero.Messaging.Message do
     field :deleted_at, :utc_datetime
 
     belongs_to :conversation, Conversation, define_field: false
-    belongs_to :sender, User, foreign_key: :sender_id, define_field: false
     has_many :attachments, Attachment, foreign_key: :message_id
 
     timestamps()

--- a/lib/klass_hero/messaging/participant.ex
+++ b/lib/klass_hero/messaging/participant.ex
@@ -11,7 +11,6 @@ defmodule KlassHero.Messaging.Participant do
 
   import Ecto.Changeset
 
-  alias KlassHero.Accounts.User
   alias KlassHero.Messaging.Conversation
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -26,7 +25,6 @@ defmodule KlassHero.Messaging.Participant do
     field :left_at, :utc_datetime
 
     belongs_to :conversation, Conversation, define_field: false
-    belongs_to :user, User, define_field: false
 
     timestamps()
   end

--- a/lib/klass_hero/provider/provider_profile.ex
+++ b/lib/klass_hero/provider/provider_profile.ex
@@ -26,8 +26,6 @@ defmodule KlassHero.Provider.ProviderProfile do
 
   import Ecto.Changeset
 
-  alias KlassHero.Accounts.User
-
   @primary_key {:id, :binary_id, autogenerate: true}
   @timestamps_opts [type: :utc_datetime]
 
@@ -116,7 +114,8 @@ defmodule KlassHero.Provider.ProviderProfile do
     field :youtube_url, :string
     field :linkedin_url, :string
 
-    belongs_to :verified_by, User, type: :binary_id
+    # Accounts owns the verifier; correlation id only, no association (#1434).
+    field :verified_by_id, :binary_id
 
     timestamps()
   end

--- a/lib/klass_hero/provider/verification_document.ex
+++ b/lib/klass_hero/provider/verification_document.ex
@@ -22,7 +22,6 @@ defmodule KlassHero.Provider.VerificationDocument do
 
   import Ecto.Changeset
 
-  alias KlassHero.Accounts.User
   # Parked alias to the still-DDD ProviderProfile schema — repointed to the
   # flattened KlassHero.Provider.ProviderProfile in Slice 5.
   alias KlassHero.Provider.DocumentType
@@ -55,7 +54,8 @@ defmodule KlassHero.Provider.VerificationDocument do
       source: :provider_id,
       references: :id
 
-    belongs_to :reviewed_by, User
+    # Accounts owns the reviewer; correlation id only, no association (#1434).
+    field :reviewed_by_id, :binary_id
 
     timestamps()
   end

--- a/lib/klass_hero/provider/verification_step.ex
+++ b/lib/klass_hero/provider/verification_step.ex
@@ -19,7 +19,6 @@ defmodule KlassHero.Provider.VerificationStep do
 
   import Ecto.Changeset
 
-  alias KlassHero.Accounts.User
   alias KlassHero.Provider.CompletedVia
   alias KlassHero.Provider.StepDefinition
   alias KlassHero.Provider.StepKey
@@ -42,8 +41,10 @@ defmodule KlassHero.Provider.VerificationStep do
     field :reviewed_at, :utc_datetime_usec
     field :submitted_at, :utc_datetime_usec
 
+    # Accounts owns the reviewer; correlation id only, no association (#1434).
+    field :reviewed_by_id, :binary_id
+
     belongs_to :vetting_case, VettingCase
-    belongs_to :reviewed_by, User
 
     timestamps()
   end

--- a/lib/klass_hero_web/live/admin/account_live.ex
+++ b/lib/klass_hero_web/live/admin/account_live.ex
@@ -6,9 +6,10 @@ defmodule KlassHeroWeb.Admin.AccountLive do
   Creation and deletion are intentionally disabled — users register
   themselves, and account deletion follows the GDPR anonymization flow.
 
-  Note: Backpex operates directly on Ecto schemas and Repo, bypassing
-  the Ports & Adapters layering used elsewhere. This is a pragmatic
-  exception scoped to admin-only read + limited edit operations.
+  Note: Backpex operates directly on the `Accounts.User` schema and Repo. That is
+  a pragmatic exception scoped to admin-only read + limited edit operations.
+  Facts owned by *other* contexts are not: the roles badges ask Family and
+  Provider through their facades (#1434).
   """
 
   # Backpex requires FQ refs in `use` args — alias can't precede `use` per formatter rules
@@ -19,17 +20,16 @@ defmodule KlassHeroWeb.Admin.AccountLive do
       repo: KlassHero.Repo,
       update_changeset: &KlassHero.Accounts.User.admin_update_changeset/3,
       # Required by Backpex even though :new is disabled via can?/3
-      create_changeset: &KlassHero.Accounts.User.admin_update_changeset/3,
-      item_query: &__MODULE__.item_query/3
+      create_changeset: &KlassHero.Accounts.User.admin_update_changeset/3
     ],
     pubsub: [server: KlassHero.PubSub],
     init_order: %{by: :inserted_at, direction: :desc},
     persist: [:columns]
 
-  import Ecto.Query
-
   alias Backpex.Fields.Boolean
   alias Backpex.Fields.Text
+  alias KlassHero.Family
+  alias KlassHero.Provider
 
   @impl Backpex.LiveResource
   def layout(_assigns), do: {KlassHeroWeb.Layouts, :admin}
@@ -44,14 +44,6 @@ defmodule KlassHeroWeb.Admin.AccountLive do
   def can?(assigns, :edit, item), do: item.id != assigns.current_scope.user.id
 
   def can?(_assigns, _action, _item), do: false
-
-  @doc false
-  # Edit only needs is_admin toggle; roles/subscription fields are index/show-only, so skip preloads.
-  def item_query(query, :edit, _assigns), do: query
-
-  def item_query(query, _live_action, _assigns) do
-    from u in query, preload: [:parent_profile, :provider_profile]
-  end
 
   @impl Backpex.LiveResource
   def singular_name, do: "Account"
@@ -82,14 +74,24 @@ defmodule KlassHeroWeb.Admin.AccountLive do
         readonly: true,
         only: [:index, :show],
         render: fn assigns ->
+          # Family and Provider own these facts; ask them per row rather than
+          # declaring an association onto their tables (#1434). Backpex exposes
+          # no page-scoped hook to batch through, so this is one indexed EXISTS
+          # per context per row, bounded by the page size.
+          assigns =
+            assign(assigns,
+              parent?: Family.has_parent_profile?(assigns.item.id),
+              provider?: Provider.has_provider_profile?(assigns.item.id)
+            )
+
           ~H"""
           <div class="flex flex-wrap gap-1">
-            <%= if @item.parent_profile do %>
+            <%= if @parent? do %>
               <span class="inline-flex items-center rounded-full px-2 py-1 text-xs font-medium bg-blue-100 text-blue-700">
                 Parent
               </span>
             <% end %>
-            <%= if @item.provider_profile do %>
+            <%= if @provider? do %>
               <span class="inline-flex items-center rounded-full px-2 py-1 text-xs font-medium bg-purple-100 text-purple-700">
                 Provider
               </span>
@@ -99,7 +101,7 @@ defmodule KlassHeroWeb.Admin.AccountLive do
                 Admin
               </span>
             <% end %>
-            <%= if !@item.parent_profile && !@item.provider_profile && !@item.is_admin do %>
+            <%= if !@parent? && !@provider? && !@item.is_admin do %>
               <span class="inline-flex items-center rounded-full px-2 py-1 text-xs font-medium bg-gray-100 text-gray-700">
                 User
               </span>

--- a/test/klass_hero/messaging/queries/message_queries_test.exs
+++ b/test/klass_hero/messaging/queries/message_queries_test.exs
@@ -213,7 +213,7 @@ defmodule KlassHero.Messaging.Queries.MessageQueriesTest do
     test "adds preloads for non-empty list" do
       query =
         MessageQueries.base()
-        |> MessageQueries.preload_assocs([:sender])
+        |> MessageQueries.preload_assocs([:attachments])
 
       assert %Ecto.Query{} = query
       assert length(query.preloads) == 1


### PR DESCRIPTION
Closes #1434.

## Summary

#1434 asks whether `accounts.ex:14`'s `alias KlassHero.Provider.StaffMember` is a boundary violation. It is not — and the alias does not change. What changes is that the codebase now *says so*, once, in the auto-loaded rule file.

The legwork found the real problem: **no rule anywhere stated what a facade returning its own entity means for callers.** ADR 0015 says a facade "owns its return types" and stops one clause short. The only place the question was addressed at all was `.claude/agents/boundary-checker.md`, per-module — the doc grade #1255 recorded as drift-prone — and its single carve-out (`Accounts.User`) is justified for `belongs_to` associations, a *different* shape than #1434 describes. Left alone, the next facade-returned entity re-runs this ticket.

Two clauses now live in `.claude/rules/domain-architecture.md` § Cross-Context Access:

1. **A facade owns its return types.** Naming what it returns — alias, typespec, pattern match, field read, re-export through your own `@spec` — is not a violation. The violation line is a query against the other context's tables.
2. **No cross-context `belongs_to`/`has_one`.** ADR 0001 already forbids the join; the association is what makes one reachable.

`boundary-checker.md`'s enumeration is replaced by pointers, in both Check 1 and Check 2 — Check 1's closing line still asserted that production code must never name another context's entity, which is the line that would have flagged `accounts.ex:14`.

## The code

A repo-wide scan found 13 sites across two shapes, and **no context queries another context's schema anywhere** — the boundary that matters was already intact. Ten cross-context associations existed; nine are gone.

| Change | Sites |
|---|---|
| Delete dead `define_field: false` associations | `email_reply`, `inbound_email`, `participant`, and `message` after its preload went |
| Replace association with explicit `field :x_id, :binary_id` | `verification_step`, `provider_profile`, `verification_document` |
| Messaging sender names via the Accounts facade | `messaging.ex` `list_messages_with_senders/2` |
| Admin roles badges via the Family/Provider facades | `admin/account_live.ex`, `accounts/user.ex` |

Three findings worth flagging to a reviewer:

- **The FK trap.** Without `define_field: false`, a `belongs_to` is the *sole* declaration of the id field — one that is cast, validated, constrained and pattern-matched. Deleting the line silently drops a column. Those four are replaced, not deleted, and the explicit `:binary_id` is required on all of them: `@foreign_key_type` governs `belongs_to` only, so a bare `field` would default to `:id`.
- **Messaging was a straggler, not a redesign.** `Accounts.get_display_names/1` already existed for exactly this — its own doc says it is there so other contexts can resolve names "without reaching into the `User` schema" — and Messaging already used it in three places. The old nil-sender guard went with the preload: it existed because `m.sender.name` raises on an unloaded association, not because a message can lack a sender (`sender_id` is `null: false`, `on_delete: :restrict`).
- **`Enrollment.program` survives, deliberately.** `Admin.BookingLive` declares a Backpex `Fields.BelongsTo` on it with `searchable`/`orderable`, which needs a real association to join. It stands on ADR 0015's cycle-breaking ground — ProgramCatalog depends on Enrollment for capacity, so Enrollment cannot call its facade, and direct `programs` access is already sanctioned for that pair. The rule records the *justification*, not the name.

## Review focus

- **`domain-architecture.md`** is the actual deliverable — the code is downstream of it.
- **The four replaced FK fields** are where a behaviour change could hide. Column types were read from the migrations.
- **`account_live.ex`** costs 2 queries per row — 30 at Backpex's default page size, each a single-row indexed `EXISTS`, on an admin-only page. Backpex offers no page-scoped seam to batch through: the generated Index/Show/Form LiveViews delegate `mount`/`handle_params` and are not overridable, `on_mount` fires per process so a batch goes stale across pagination patches, and `item_query/3` returns a query so batching there means the join ADR 0001 forbids.

## Test plan

- `mix precommit` green: credo clean over 924 files, 5375 tests pass, every `lint_*` task included.
- No migration. DB-level foreign keys are untouched; only Ecto association declarations changed.
- The existing suites are the safety net — "they pass unchanged" is the criterion for every step. `account_live_test.exs`'s 6 badge tests and `message_test.exs`'s `sender_names` assertion are the load-bearing ones.

## Follow-up

Worth its own issue: `AccountLive`'s roles badge answers *"does a profile row exist"*, while `user.intended_roles` would answer *"what did the signup form say"*. They are not the same fact — profiles are created asynchronously by an outbox/Oban fan-out on `user_registered` and diverge permanently if that event is discarded — so today's badge silently doubles as the only admin-visible drift detector for lost profile-creation events. Keeping that deliberately or replacing it with real observability is a product decision, not a side effect of this refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016h9qLCRgvgdFSBPdjAkZQi